### PR TITLE
Issue #22 : iOS crop non working for images with orientation.

### DIFF
--- a/ios/Classes/FlutterNativeImagePlugin.m
+++ b/ios/Classes/FlutterNativeImagePlugin.m
@@ -122,6 +122,7 @@
         NSData *data = [[NSFileManager defaultManager] contentsAtPath:path];
         
         UIImage *img = [[UIImage alloc] initWithData:data];
+        img = [self normalizedImage:img];
 
         if(originX<0 || originY<0 
         	|| originX>img.size.width || originY>img.size.height 


### PR DESCRIPTION
Following this discussion, I'm proposing a fix: https://github.com/btastic/flutter_native_image/issues/22

The crop method did not normalize the image and therefore crops the wrong group of pixels if any orientation is present.
The normalized function was already present in the file for the compress method.