### PR TITLE
Fixed #33: Added orientation property to ImageProperties

### DIFF
--- a/android/src/main/java/com/example/flutternativeimage/FlutterNativeImagePlugin.java
+++ b/android/src/main/java/com/example/flutternativeimage/FlutterNativeImagePlugin.java
@@ -109,13 +109,14 @@ public class FlutterNativeImagePlugin implements MethodCallHandler {
       properties.put("width", options.outWidth);
       properties.put("height", options.outHeight);
 
+      int orientation = ExifInterface.ORIENTATION_UNDEFINED;
       try {
         ExifInterface exif = new ExifInterface(fileName);
-        int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED);
-        properties.put("orientation", orientation);
+        orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED);
       } catch(IOException ex) {
-        // ignore
+        // EXIF could not be read from the file; ignore
       }
+      properties.put("orientation", orientation);
 
       result.success(properties);
       return;

--- a/android/src/main/java/com/example/flutternativeimage/FlutterNativeImagePlugin.java
+++ b/android/src/main/java/com/example/flutternativeimage/FlutterNativeImagePlugin.java
@@ -105,10 +105,17 @@ public class FlutterNativeImagePlugin implements MethodCallHandler {
       BitmapFactory.Options options = new BitmapFactory.Options();
       options.inJustDecodeBounds = true;
       BitmapFactory.decodeFile(fileName,options);
-
       HashMap<String, Integer> properties = new HashMap<String, Integer>();
-      properties.put("width",options.outWidth);
-      properties.put("height",options.outHeight);
+      properties.put("width", options.outWidth);
+      properties.put("height", options.outHeight);
+
+      try {
+        ExifInterface exif = new ExifInterface(fileName);
+        int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED);
+        properties.put("orientation", orientation);
+      } catch(IOException ex) {
+        // ignore
+      }
 
       result.success(properties);
       return;

--- a/ios/Classes/FlutterNativeImagePlugin.m
+++ b/ios/Classes/FlutterNativeImagePlugin.m
@@ -79,8 +79,16 @@
         NSData *data = [[NSFileManager defaultManager] contentsAtPath:path];
 
         UIImage *img = [[UIImage alloc] initWithData:data];
-
-        NSDictionary *dict = @{ @"width" : @(lroundf(img.size.width)), @"height" : @(lroundf(img.size.height))};
+        
+        // Class ALAsset that provides a way to get EXIF attributes has been deprecated since iOS 8+,
+        // but the replacing class PHAsset does not have a way to obtain image orientation.
+        // For the purposes of FlutterNativeImagePlgin it's ok to leave it as undefined, as
+        // all images captured/stored on iOS effectively have "normal" orientation so
+        // it should not affect image crop/resize operations.
+        int orientation = 0; // undefined orientation
+        NSDictionary *dict = @{ @"width" : @(lroundf(img.size.width)),
+                                @"height" : @(lroundf(img.size.height)),
+                                @"orientation": @((NSInteger)orientation)};
 
         result(dict);
         return;

--- a/lib/flutter_native_image.dart
+++ b/lib/flutter_native_image.dart
@@ -25,9 +25,26 @@ class FlutterNativeImage {
   }
 
   static Future<ImageProperties> getImageProperties(String fileName) async {
+
+    ImageOrientation decodeOrientation(int orientation) {
+      // For details, see: https://developer.android.com/reference/android/media/ExifInterface
+      switch(orientation) {
+        case 1: return ImageOrientation.normal;
+        case 2: return ImageOrientation.flipHorizontal;
+        case 3: return ImageOrientation.rotate180;
+        case 4: return ImageOrientation.flipVertical;
+        case 5: return ImageOrientation.transpose;
+        case 6: return ImageOrientation.rotate90;
+        case 7: return ImageOrientation.transverse;
+        case 8: return ImageOrientation.rotate270;
+        default: return ImageOrientation.undefined;
+      }
+    }
+
     var properties =
         Map.from(await _channel.invokeMethod("getImageProperties", {'file': fileName}));
-    return new ImageProperties(width: properties["width"], height: properties["height"]);
+    return new ImageProperties(width: properties["width"], height: properties["height"],
+                               orientation: decodeOrientation(properties["orientation"]));
   }
 
   static Future<File> cropImage(
@@ -44,12 +61,22 @@ class FlutterNativeImage {
   }
 }
 
+enum ImageOrientation {
+  normal,
+  rotate90,
+  rotate180,
+  rotate270,
+  flipHorizontal,
+  flipVertical,
+  transpose,
+  transverse,
+  undefined,
+}
+
 class ImageProperties {
   int width;
   int height;
+  ImageOrientation orientation;
 
-  ImageProperties({int width = 0, int height = 0}) {
-    this.width = width;
-    this.height = height;
-  }
+  ImageProperties({this.width = 0, this.height = 0, this.orientation = ImageOrientation.undefined});
 }


### PR DESCRIPTION
Obtaining image orientation from EXIF header on Android. Setting orientation to Undefined on iOS, since EXIF API is deprecated and since image orientation on the images stored in Photos is always normal.
 