### PR TITLE
Fix Android filter flag

### DIFF
--- a/android/src/main/java/com/example/flutternativeimage/FlutterNativeImagePlugin.java
+++ b/android/src/main/java/com/example/flutternativeimage/FlutterNativeImagePlugin.java
@@ -66,7 +66,7 @@ public class FlutterNativeImagePlugin implements MethodCallHandler {
       int newHeight = targetHeight == 0 ? (bmp.getHeight() / 100 * resizePercentage) : targetHeight;
 
       bmp = Bitmap.createScaledBitmap(
-              bmp, newWidth, newHeight, false);
+              bmp, newWidth, newHeight, true);
 
       bmp.compress(Bitmap.CompressFormat.JPEG, quality, bos);
 


### PR DESCRIPTION
Currently, the library uses nearest neighbor scaling which creates a bunch of artifacts. This sets the filter property to true in createScaledBitmap. Per the docs (https://developer.android.com/reference/android/graphics/Bitmap.html#createScaledBitmap(android.graphics.Bitmap,%20int,%20int,%20boolean)):

>filter | boolean: Whether or not bilinear filtering should be used when scaling the bitmap. If this is true then bilinear filtering will be used when scaling which has better image quality at the cost of worse performance. If this is false then nearest-neighbor scaling is used instead which will have worse image quality but is faster. Recommended default is to set filter to 'true' as the cost of bilinear filtering is typically minimal and the improved image quality is significant.